### PR TITLE
Python2.6 unittest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycurl
 pyrpm
 argcomplete
 mock
+unittest2

--- a/src/main/python/teamcity_test_runner_extension/teamcityTestRunner.py
+++ b/src/main/python/teamcity_test_runner_extension/teamcityTestRunner.py
@@ -1,4 +1,4 @@
-from unittest import TestLoader
+from unittest2 import TestLoader
 from setuptools.command.test import test
 
 from teamcity.unittestpy import TeamcityTestRunner, TeamcityTestResult


### PR DESCRIPTION
Using python 2.6 on a CentOS 6.5 machine I got an error running the tests through jenkins:

``` bash
$ python setup.py test
running test
Traceback (most recent call last):
  File "setup.py", line 68, in <module>
    install_requires=['pycurl', 'argcomplete', 'simplejson'],
  File "/usr/lib64/python2.6/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib64/python2.6/distutils/dist.py", line 975, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command
    cmd_obj.run()
  File "src/main/python/teamcity_test_runner_extension/teamcityTestRunner.py", line 37, in run
    testSuite = testloader.discover(self.test_suite, top_level_dir='src/main/python')
AttributeError: 'TestLoader' object has no attribute 'discover'
```

I found a sort of solution by installing unittest2 and refering the import to unittest2 instead of unittest, not sure if it's the correct way to go but the tests are running again :)

This issue is probably related to python2.6 only I did not tested it using other version of python..
